### PR TITLE
Add network energy metric and demo

### DIFF
--- a/demos/streamlit_app.py
+++ b/demos/streamlit_app.py
@@ -548,11 +548,14 @@ class SynthNNDemo:
                 spectrum, fundamental, coherence = self.analyze_audio(audio)
                 
                 # Display metrics
-                col1, col2 = st.columns(2)
+                col1, col2, col3 = st.columns(3)
                 with col1:
                     st.metric("Fundamental Frequency", f"{fundamental:.2f} Hz" if fundamental else "N/A")
                 with col2:
                     st.metric("Average Phase Coherence", f"{np.mean(coherence):.3f}" if coherence else "N/A")
+                with col3:
+                    energy = network.measure_total_energy()
+                    st.metric("Network Energy", f"{energy:.3f}")
                 
                 # Spectrum plot
                 fig_spec, ax_spec = plt.subplots(figsize=(10, 4))

--- a/synthnn/core/resonant_network.py
+++ b/synthnn/core/resonant_network.py
@@ -171,6 +171,9 @@ class ResonantNetwork:
             self.history[f'phase_{node_id}'].append(node.phase)
             self.history[f'amplitude_{node_id}'].append(node.amplitude)
             self.history[f'signal_{node_id}'].append(node.oscillate(self.time))
+
+        # Record global metrics
+        self.history['total_energy'].append(self.measure_total_energy())
     
     def get_signals(self, node_ids: Optional[List[str]] = None) -> Dict[str, float]:
         """Get current signals from specified nodes (or all nodes)."""
@@ -283,5 +286,23 @@ class ResonantNetwork:
         for conn_str, conn_data in state['connections'].items():
             src, tgt = conn_str.split('->')
             network.connect(src, tgt, conn_data['weight'], conn_data['delay'])
-        
-        return network 
+
+        return network
+
+    def measure_total_energy(self, node_group: Optional[List[str]] = None) -> float:
+        """Calculate the total energy of the network or a subset of nodes."""
+        if node_group is None:
+            node_group = list(self.nodes.keys())
+
+        return sum(
+            self.nodes[nid].energy() for nid in node_group if nid in self.nodes
+        )
+
+    def get_network_statistics(self) -> Dict[str, float]:
+        """Return basic statistics about the current network state."""
+        return {
+            'num_nodes': len(self.nodes),
+            'num_connections': len(self.connections),
+            'synchronization': self.measure_synchronization(),
+            'total_energy': self.measure_total_energy(),
+        }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,6 +42,7 @@ for _ in range(10):
     network.step(0.01)
 final_sync = network.measure_synchronization()
 print(f"Final synchronization: {final_sync:.4f}")
+print(f"Network total energy: {network.measure_total_energy():.4f}")
 
 # Test SignalProcessor
 print("\n--- Testing SignalProcessor ---")


### PR DESCRIPTION
## Summary
- add `measure_total_energy` and `get_network_statistics` to `ResonantNetwork`
- record network energy in history
- show network energy metric in Streamlit analysis tab
- update core test to display network energy

## Testing
- `pytest -q` *(fails: ModeDetector missing `detect_mode`; anomaly detection assertion fails; module import error in tests)*